### PR TITLE
Session state commit

### DIFF
--- a/c-wrapper/link_rs.cpp
+++ b/c-wrapper/link_rs.cpp
@@ -52,7 +52,7 @@ WClock* Link_clock(WLink* lp) {
 
 void Link_withAudioSessionState(WLink* lp, RustClosurePtr cp, void* closure_data) {
     auto ss = reinterpret_cast<ableton::Link*>(lp)->captureAudioSessionState();
-    cp(closure_data, reinterpret_cast<WSessionState*>(&ss));
+    cp(closure_data, reinterpret_cast<WSessionState*>(&ss), lp);
 }
 
 void Link_commitAudioSessionState(WLink* lp, WSessionState* ssp) {
@@ -68,7 +68,7 @@ WSessionState* Link_captureAppSessionState(WLink* lp) {
 
 void Link_withAppSessionState(WLink* lp, RustClosurePtr cp, void* closure_data) {
     auto ss = reinterpret_cast<ableton::Link*>(lp)->captureAppSessionState();
-    cp(closure_data, reinterpret_cast<WSessionState*>(&ss));
+    cp(closure_data, reinterpret_cast<WSessionState*>(&ss), lp);
 }
 
 void Link_commitAppSessionState(WLink* lp, WSessionState* ssp) {
@@ -78,7 +78,7 @@ void Link_commitAppSessionState(WLink* lp, WSessionState* ssp) {
 
 // SessionState
 
-void SessionState_destroy(WSessionState* ssp) { 
+void SessionState_destroy(WSessionState* ssp) {
     delete reinterpret_cast<ableton::Link::SessionState*>(ssp);
 }
 
@@ -170,4 +170,3 @@ uint64_t Clock_ticks(WClock* cp) {
 int64_t Clock_micros(WClock* cp) {
     return reinterpret_cast<ableton::Link::Clock*>(cp)->micros().count();
 }
-

--- a/c-wrapper/link_rs.h
+++ b/c-wrapper/link_rs.h
@@ -3,13 +3,13 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {  
+extern "C" {
 #endif
 
 typedef struct WLink WLink;
 typedef struct WSessionState WSessionState;
 typedef struct WClock WClock;
-typedef void (*RustClosurePtr)(void*, WSessionState*);
+typedef void (*RustClosurePtr)(void*, WSessionState*, WLink*);
 
 // Link
 

--- a/src/bin/link-hut.rs
+++ b/src/bin/link-hut.rs
@@ -1,0 +1,22 @@
+extern crate ableton_link;
+
+use ableton_link::{Link};
+use std::time::Duration;
+use std::thread::sleep;
+
+fn main()
+{
+    let mut link = Link::new(120.0);
+    let clock = link.clock();
+    loop
+    {
+        link.with_app_session_state(|mut session_state|
+        {
+            let now = clock.micros();
+            println!("now: {:?}", now);
+            sleep(Duration::from_millis(100));
+            session_state.set_tempo(122.0, 0);
+            session_state.commit();
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! An overview of Link concepts can be found at
 //! [http://ableton.github.io/link](http://ableton.github.io/link).
-//! 
+//!
 //! Then see the doc of [Link](struct.Link.html) and
 //! [SessionState](struct.SessionState.html).
 //! Most of it is directly taken from the original Link docs.
-//! 
+//!
 //! All i64 time values are in microseconds and should be used with the
 //! [Clock](struct.Clock.html).
 
@@ -18,7 +18,7 @@ use sys::*;
 use std::os::raw::c_void;
 
 /// # Represents a participant in a Link session.
-/// 
+///
 /// Each Link instance has its own session state which
 /// represents a beat timeline and a transport start/stop state. The
 /// timeline starts running from beat 0 at the initial tempo when
@@ -27,20 +27,20 @@ use std::os::raw::c_void;
 /// transport start/stop state of Link is optional for every peer.
 /// The transport start/stop state is only shared with other peers when
 /// start/stop synchronization is enabled.
-/// 
+///
 /// A Link instance is initially disabled after construction, which
 /// means that it will not communicate on the network. Once enabled,
 /// a Link instance initiates network communication in an effort to
 /// discover other peers. When peers are discovered, they immediately
 /// become part of a shared Link session.
-/// 
+///
 /// Each method of the Link type documents its thread-safety and
 /// realtime-safety properties. When a method is marked thread-safe,
 /// it means it is safe to call from multiple threads
 /// concurrently. When a method is marked realtime-safe, it means that
 /// it does not block and is appropriate for use in the thread that
 /// performs audio IO.
-/// 
+///
 /// Link provides one session state capture/commit method pair for use
 /// in the audio thread and one for all other application contexts. In
 /// general, modifying the session state should be done in the audio
@@ -107,7 +107,7 @@ impl Link {
     /// peers in the Link session changes.
     /// * Thread-safe: yes
     /// * Realtime-safe: no
-    /// 
+    ///
     /// The callback is invoked on a Link-managed thread.
     pub fn set_num_peers_callback(&mut self, callback: extern fn(usize)) {
         unsafe {
@@ -119,7 +119,7 @@ impl Link {
     /// Register a callback to be notified when the session tempo changes.
     /// * Thread-safe: yes
     /// * Realtime-safe: no
-    /// 
+    ///
     /// The callback is invoked on a Link-managed thread.
     pub fn set_tempo_callback(&mut self, callback: extern fn(f64)) {
         unsafe {
@@ -132,7 +132,7 @@ impl Link {
     /// start/stop isPlaying changes.
     /// * Thread-safe: yes
     /// * Realtime-safe: no
-    /// 
+    ///
     /// The callback is invoked on a Link-managed thread.
     pub fn set_start_stop_callback(&mut self, callback: extern fn(bool)) {
         unsafe {
@@ -144,7 +144,7 @@ impl Link {
     /// The clock used by Link.
     /// * Thread-safe: yes
     /// * Realtime-safe: yes
-    /// 
+    ///
     /// The Clock type is a platform-dependent
     /// representation of the system clock. It exposes a `ticks()` method
     /// that returns the current ticks of the system clock as well as
@@ -159,7 +159,7 @@ impl Link {
     // Capture the current Link Session State from the audio thread.
     // * Thread-safe: no
     // * Realtime-safe: yes
-    // 
+    //
     // This method should ONLY be called in the audio thread
     // and must not be accessed from any other threads. The returned
     // object stores a snapshot of the current Link Session State, so it
@@ -173,7 +173,7 @@ impl Link {
     /// Capture the current Link Session State from the audio thread.
     /// * Thread-safe: no
     /// * Realtime-safe: yes
-    /// 
+    ///
     /// This method should ONLY be called in the audio thread
     /// and must not be accessed from any other threads. The closure
     /// passes a snapshot of the current Link Session State, it
@@ -203,7 +203,7 @@ impl Link {
     /// Commit the given Session State to the Link session from the audio thread.
     /// * Thread-safe: no
     /// * Realtime-safe: yes
-    /// 
+    ///
     /// This method should ONLY be called in the audio
     /// thread. The given Session State will replace the current Link
     /// state. Modifications will be communicated to other peers in the
@@ -215,7 +215,7 @@ impl Link {
     // Capture the current Link Session State from an application thread.
     // * Thread-safe: yes
     // * Realtime-safe: no
-    // 
+    //
     // Provides a mechanism for capturing the Link Session
     // State from an application thread (other than the audio thread).
     // The returned Session State stores a snapshot of the current Link
@@ -230,7 +230,7 @@ impl Link {
     /// Capture the current Link Session State from an application thread.
     /// * Thread-safe: yes
     /// * Realtime-safe: no
-    /// 
+    ///
     /// Provides a mechanism for capturing the Link Session
     /// State from an application thread (other than the audio thread).
     /// The closure passes a Session State that stores a snapshot of the current Link
@@ -261,7 +261,7 @@ impl Link {
     /// application thread.
     /// * Thread-safe: yes
     /// * Realtime-safe: no
-    /// 
+    ///
     /// The given Session State will replace the current Link
     /// Session State. Modifications of the Session State will be
     /// communicated to other peers in the session.
@@ -271,16 +271,16 @@ impl Link {
 }
 
 /// # Representation of a timeline and the start/stop state
-/// 
+///
 /// A SessionState object is intended for use in a local scope within
 /// a single thread - none of its methods are thread-safe. All of its methods are
 /// non-blocking, so it is safe to use from a realtime thread.
 /// It provides functions to observe and manipulate the timeline and start/stop
 /// state.
-/// 
+///
 /// The timeline is a representation of a mapping between time and beats for varying
 /// quanta.
-/// 
+///
 /// The start/stop state represents the user intention to start or stop transport at
 /// a specific time. Start stop synchronization is an optional feature that allows to
 /// share the user request to start or stop transport between a subgroup of peers in
@@ -325,7 +325,7 @@ impl SessionState {
     }
 
     /// Get the session phase at the given time for the given quantum.
-    /// 
+    ///
     /// The result is in the interval [0, quantum). The
     /// result is equivalent to fmod(beatAtTime(t, q), q) for
     /// non-negative beat values. This method is convenient if the
@@ -338,7 +338,7 @@ impl SessionState {
 
     /// Get the time at which the given beat occurs for the
     /// given quantum.
-    /// 
+    ///
     /// The inverse of beatAtTime, assuming a constant
     /// tempo. beatAtTime(timeAtBeat(b, q), q) === b.
     pub fn time_at_beat(&self, beat: f64, quantum: f64) -> i64 {
@@ -347,21 +347,21 @@ impl SessionState {
 
     /// Attempt to map the given beat to the given time in the
     /// context of the given quantum.
-    /// 
+    ///
     /// This method behaves differently depending on the
     /// state of the session. If no other peers are connected,
     /// then this instance is in a session by itself and is free to
     /// re-map the beat/time relationship whenever it pleases. In this
     /// case, beatAtTime(time, quantum) == beat after this method has
     /// been called.
-    /// 
+    ///
     /// If there are other peers in the session, this instance
     /// should not abruptly re-map the beat/time relationship in the
     /// session because that would lead to beat discontinuities among
     /// the other peers. In this case, the given beat will be mapped
     /// to the next time value greater than the given time with the
     /// same phase as the given beat.
-    /// 
+    ///
     /// This method is specifically designed to enable the concept of
     /// "quantized launch" in client applications. If there are no other
     /// peers in the session, then an event (such as starting
@@ -378,7 +378,7 @@ impl SessionState {
 
     /// Rudely re-map the beat/time relationship for all peers
     /// in a session.
-    /// 
+    ///
     /// DANGER: This method should only be needed in
     /// certain special circumstances. Most applications should not
     /// use it. It is very similar to requestBeatAtTime except that it
@@ -387,7 +387,7 @@ impl SessionState {
     /// unconditionally map the given beat to the given time and
     /// broadcast the result to the session. This is very anti-social
     /// behavior and should be avoided.
-    /// 
+    ///
     /// One of the few legitimate uses of this method is to
     /// synchronize a Link session with an external clock source. By
     /// periodically forcing the beat/time mapping according to an
@@ -428,7 +428,7 @@ impl SessionState {
     pub fn set_is_playing_and_request_beat_at_time(&mut self,
         is_playing: bool, time: i64, beat: f64, quantum: f64) {
 
-        unsafe { SessionState_setIsPlayingAndRequestBeatAtTime(self.wss, 
+        unsafe { SessionState_setIsPlayingAndRequestBeatAtTime(self.wss,
             is_playing, time, beat, quantum) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub struct Link {
     wlink: *mut WLink,
 }
 
+unsafe impl Send for Link {}
+unsafe impl Sync for Link {}
+
 impl Drop for Link {
     fn drop(&mut self) {
         unsafe { Link_destroy(self.wlink) }


### PR DESCRIPTION
I couldn't get the link.commit_*_session_state to work because the compiler would complain about a double borrow. Which makes sense to my Rust noob brain: invoking link.with_*_session_state(|ss| { ... }) means we borrow line for the runtime of the closure. Invoking it again in there is the second borrow. 

So I tried a different design that also removes possible ambiguity with the two different session state sources. SessionState now knows if it was created from app or audio, and keeps a pointer to WLink. Thus it can provide it's own commit, and that works for me.

Let me know what you think.